### PR TITLE
feat: add guro.pages.dev as project homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 Guro is a sophisticated terminal-based diagnostic toolkit designed for granular system resource monitoring and hardware analysis. Built for engineers and enthusiasts, it provides a desktop-class dashboard experience within the command-line environment, delivering precise telemetry across Linux, macOS, and Windows.
 
+🌐 **Website**: [guro.pages.dev](https://guro.pages.dev/)
+
 ---
 
 ## Visual Presentation
@@ -80,6 +82,7 @@ Access Guro via its unified command-line interface.
 
 Guro is an open-source project that adheres to professional development standards.
 
+- **Website**: [guro.pages.dev](https://guro.pages.dev/)
 - **Developer Guide**: Comprehensive guidelines can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
 - **Architecture**: In-depth module analysis is available in the project documentation.
 - **License**: Released under the MIT License.

--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -382,6 +382,7 @@
     Built with ❤️ by <span class="hl">Dhanush Kandhan</span> · MIT License · <span class="hl">guro</span>
   </div>
   <ul class="footer-links">
+    <li><a href="https://guro.pages.dev/" target="_blank">Website</a></li>
     <li><a href="https://github.com/dhanushk-offl/guro" target="_blank">GitHub</a></li>
     <li><a href="https://pypi.org/project/guro/" target="_blank">PyPI</a></li>
     <li><a href="https://github.com/dhanushk-offl/guro/blob/master/CONTRIBUTING.md" target="_blank">Contribute</a></li>

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -11,6 +11,12 @@ Welcome to the technical documentation for Guro. This wiki provides in-depth ana
 - [Platform Implementation Details](Platform-Support.md)
 - [Troubleshooting and Diagnostics](Troubleshooting.md)
 
+## Project Links
+
+- **Website**: [guro.pages.dev](https://guro.pages.dev/)
+- **Source Code**: [github.com/dhanushk-offl/guro](https://github.com/dhanushk-offl/guro)
+- **Issue Tracker**: [github.com/dhanushk-offl/guro/issues](https://github.com/dhanushk-offl/guro/issues)
+
 ## Project Vision
 
 Guro is designed to provide high-fidelity system telemetry in a lightweight, terminal-based format. By prioritizing robust data acquisition and structured visualization, Guro serves as a reliable diagnostic bridge between low-level system sensors and the end-user.

--- a/pytoml.toml
+++ b/pytoml.toml
@@ -79,7 +79,8 @@ all = [
 [project.urls]
 "Bug Reports" = "https://github.com/dhanushk-offl/guro/issues"
 "Source" = "https://github.com/dhanushk-offl/guro"
-"Documentation" = "https://github.com/dhanushk-offl/guro/wiki"
+"Documentation" = "https://guro.pages.dev/"
+"Homepage" = "https://guro.pages.dev/"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     description="A System Tool-kit for Real-time Monitoring and Analysis",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
-    url="https://github.com/dhanushk-offl/guro",
+    url="https://guro.pages.dev/",
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
@@ -82,7 +82,8 @@ setup(
     project_urls={
         "Bug Reports": "https://github.com/dhanushk-offl/guro/issues",
         "Source": "https://github.com/dhanushk-offl/guro",
-        "Documentation": "https://github.com/dhanushk-offl/guro/wiki"
+        "Documentation": "https://guro.pages.dev/",
+        "Homepage": "https://guro.pages.dev/"
     },
     extras_require={
         'nvidia': ['py3nvml>=0.2.7', 'nvidia-ml-py>=11.515.0'],

--- a/src/guro/cli/main.py
+++ b/src/guro/cli/main.py
@@ -195,7 +195,8 @@ def about():
 • 🌡️ Hardware Heatmap Analysis (Hottest component tracking)
 
 [blue]GitHub:[/blue] https://github.com/dhanushk-offl/guro
-[blue]Documentation:[/blue] https://github.com/dhanushk-offl/guro/wiki"""
+[blue]Website:[/blue] https://guro.pages.dev/
+[blue]Documentation:[/blue] https://guro.pages.dev/"""
 
     console.print(Panel(about_text, title="About Guro", border_style="blue"))
 


### PR DESCRIPTION
Add https://guro.pages.dev/ as the official project website across all relevant project metadata surfaces:

- README.md: Add website link in Overview and Community sections
- pytoml.toml: Update Documentation + add Homepage project URLs
- setup.py: Update url, Documentation, and add Homepage project URLs
- src/guro/cli/main.py: Add Website line in the 'about' command
- docs/wiki/Home.md: Add Project Links section with website URL
- docs/web/index.html: Add Website link to footer navigation