### PR TITLE
fix: resolve YAML quoting error in publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Get version from _version.py
         id: version
         run: |
-          VERSION=$(python -c "import re; f=open('src/guro/_version.py'); print(re.search(r'__version__\s*=\s*[\"']([^\"']+)', f.read()).group(1))")
+          VERSION=$(python -c "exec(open('src/guro/_version.py').read()); print(__version__)")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes


### PR DESCRIPTION
The github-release job used a Python one-liner with nested quotes that broke in YAML/shell quoting. Swapped to `exec(open(...).read())` which is clean and unambiguous.