### PR TITLE
fix: rename pytoml.toml to pyproject.toml and fix MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 include README.md
 include LICENSE
 include SECURITY.md
-recursive-include guro *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ name = "guro"
 dynamic = ["version"]
 description = "A System Tool-kit for Real-time Monitoring and Analysis"
 readme = "README.md"
-long-description-content-type = "text/markdown"
 authors = [
     {name = "Dhanush Kandhan", email = "dhanushkandhan75@gmail.com"}
 ]


### PR DESCRIPTION
## Changes

- Renamed `pytoml.toml` → `pyproject.toml` (standard filename pip/build tools expect)
- Removed invalid `long-description-content-type` field from pyproject.toml
- Removed broken `recursive-include guro *` from MANIFEST.in (wrong path, unnecessary)

## Why

- `pyproject.toml` is the PEP 621 standard — build tools ignore `pytoml.toml`
- `long-description-content-type` is invalid in `[project]` table and blocks builds
- Package is under `src/guro/`, not `guro/`, so the MANIFEST glob matched nothing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manifest configuration to explicitly include security documentation.
  * Removed project metadata field from configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->